### PR TITLE
replace default with NULL

### DIFF
--- a/hidapi/mac/hid.c
+++ b/hidapi/mac/hid.c
@@ -690,7 +690,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		return NULL;
 
 	/* Get the IORegistry entry for the given path */
-	entry = IORegistryEntryFromPath(kIOMainPortDefault, path);
+	entry = IORegistryEntryFromPath(MACH_PORT_NULL, path);
 	if (entry == MACH_PORT_NULL) {
 		/* Path wasn't valid (maybe device was removed?) */
 		goto return_error;

--- a/libusb/libusb/os/darwin_usb.c
+++ b/libusb/libusb/os/darwin_usb.c
@@ -235,7 +235,7 @@ static int usb_setup_device_iterator (io_iterator_t *deviceIterator, UInt32 loca
     /* else we can still proceed as long as the caller accounts for the possibility of other devices in the iterator */
   }
 
-  return IOServiceGetMatchingServices(kIOMasterPortDefault, matchingDict, deviceIterator);
+  return IOServiceGetMatchingServices(MACH_PORT_NULL, matchingDict, deviceIterator);
 }
 
 /* Returns 1 on success, 0 on failure. */
@@ -370,7 +370,7 @@ static void darwin_hotplug_poll (void)
   /* since a kernel thread may nodify the IOInterators used for
    * hotplug notidication we can't just clear the iterators.
    * instead just wait until all IOService providers are quiet */
-  (void) IOKitWaitQuiet (kIOMasterPortDefault, &timeout);
+  (void) IOKitWaitQuiet (MACH_PORT_NULL, &timeout);
 }
 
 static void darwin_clear_iterator (io_iterator_t iter) {
@@ -421,7 +421,7 @@ static void *darwin_event_thread_main (void *arg0) {
   CFRunLoopAddSource(runloop, libusb_darwin_acfls, kCFRunLoopDefaultMode);
 
   /* add the notification port to the run loop */
-  libusb_notification_port     = IONotificationPortCreate (kIOMasterPortDefault);
+  libusb_notification_port     = IONotificationPortCreate (MACH_PORT_NULL);
   libusb_notification_cfsource = IONotificationPortGetRunLoopSource (libusb_notification_port);
   CFRunLoopAddSource(runloop, libusb_notification_cfsource, kCFRunLoopDefaultMode);
 
@@ -695,7 +695,7 @@ static int darwin_check_configuration (struct libusb_context *ctx, struct darwin
   } else
     /* not configured */
     dev->active_config = 0;
-  
+
   usbi_dbg ("active config: %u, first config: %u", dev->active_config, dev->first_config);
 
   return 0;


### PR DESCRIPTION
Set NULL as input param for IOKit functions instead of **kIOMainPortDefault** or **kIOMasterPortDefault** that was changed in macOS 12.0.

```
When specifying a main port to IOKit functions, the NULL argument
indicates "use the default".
```
https://developer.apple.com/documentation/iokit/kiomasterportdefault