### PR TITLE
fix: warning for `sys/poll.h`

### DIFF
--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -19,7 +19,7 @@ package hid
 #cgo windows LDFLAGS: -lsetupapi
 
 #ifdef OS_LINUX
-	#include <sys/poll.h>
+	#include <poll.h>
 	#include "os/threads_posix.c"
 	#include "os/poll_posix.c"
 


### PR DESCRIPTION
Closes https://github.com/Zondax/hid/issues/10

Inspired by this PR in upstream: https://github.com/karalabe/hid/pull/18. I haven't tested that this resolves the warning but I expect it to.