### PR TITLE
OS X enumerate fix: also look for IOKit in /System/Library/Frameworks

### DIFF
--- a/hidapi/mac/hid.c
+++ b/hidapi/mac/hid.c
@@ -303,7 +303,11 @@ static io_service_t hidapi_IOHIDDeviceGetService(IOHIDDeviceRef device)
 	 * and the fallback method will be used.
 	 */
 	if (iokit_framework == NULL) {
-		iokit_framework = dlopen("/System/Library/IOKit.framework/IOKit", RTLD_LAZY);
+		iokit_framework = dlopen("/System/Library/Frameworks/IOKit.framework/IOKit", RTLD_LAZY);
+
+		if (iokit_framework == NULL) {
+			iokit_framework = dlopen("/System/Library/IOKit.framework/IOKit", RTLD_LAZY);
+		}
 
 		if (iokit_framework != NULL)
 			dynamic_IOHIDDeviceGetService = dlsym(iokit_framework, "IOHIDDeviceGetService");


### PR DESCRIPTION
It appears the location of the library has moved recently.